### PR TITLE
add custom feedback

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -32,7 +32,7 @@ class MyApp extends StatelessWidget {
         body: MegaGrid(
           items: items,
           columns: columns,
-          width: 1000,
+          feedback: (t) => customFeedback(t),
           style: MegaGridStyle(
             headerTextStyle: const TextStyle(fontWeight: FontWeight.bold),
             cellTextStyle: const TextStyle(color: Colors.black),
@@ -49,3 +49,22 @@ class MyApp extends StatelessWidget {
     );
   }
 }
+
+Widget Function(String) customFeedback = (String? value) {
+  return Material(
+    elevation: 4,
+    borderRadius: BorderRadius.circular(12),
+    child: Container(
+      padding: const EdgeInsets.all(8),
+      decoration: BoxDecoration(
+        color: const Color.fromARGB(255, 114, 200, 219).withOpacity(0.1),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(children: [
+        Text(value ?? ""),
+        const Icon(Icons.query_stats),
+        // const Icon(Icons.drag_indicator),
+      ]),
+    ),
+  );
+};

--- a/lib/src/ui/mega_grid/mega_grid_style.dart
+++ b/lib/src/ui/mega_grid/mega_grid_style.dart
@@ -12,7 +12,9 @@ class MegaGridStyle {
   final Border? border;
   final Color? borderColor;
   final double? borderWidth;
-
+  final Color? feedbackBgColor;
+  final Color? feedbackTextColor;
+  
   const MegaGridStyle({
     this.headerTextStyle,
     this.cellTextStyle,
@@ -25,5 +27,7 @@ class MegaGridStyle {
     this.border,
     this.borderColor,
     this.borderWidth,
+    this.feedbackBgColor,
+    this.feedbackTextColor,
   });
 }

--- a/lib/src/ui/mega_grid/mega_grid_widget.dart
+++ b/lib/src/ui/mega_grid/mega_grid_widget.dart
@@ -10,6 +10,7 @@ class MegaGrid extends StatefulWidget {
   final double? width;
   final double? height;
   final double minColumnWidth;
+  final Widget Function(String text)? feedback;
 
   const MegaGrid({
     super.key,
@@ -19,6 +20,7 @@ class MegaGrid extends StatefulWidget {
     this.width,
     this.height,
     this.minColumnWidth = 70.0,
+    this.feedback,
   });
 
   @override
@@ -113,7 +115,7 @@ class MegaGridState extends State<MegaGrid> {
     );
   }
 
-  Widget _buildHeaderCell(MegaColumn column, int index) {
+  Widget _buildHeaderCell(MegaColumn column, int index, Widget Function(String title)? feedback) {
     return Container(
       width: _columnWidths[index],
       decoration: BoxDecoration(
@@ -133,24 +135,26 @@ class MegaGridState extends State<MegaGrid> {
             padding: const EdgeInsets.all(8),
             child: Draggable<int>(
               data: index,
-              feedback: Material(
-                elevation: 4,
-                borderRadius: BorderRadius.circular(12),
-                child: Container(
-                  padding: const EdgeInsets.all(8),
-                  decoration: BoxDecoration(
-                    color: Colors.grey.withOpacity(0.8),
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                  child: Text(
-                    column.title,
-                    style: widget.style?.headerTextStyle?.copyWith(
-                      color: Colors.white,
-                      fontWeight: FontWeight.bold,
+              feedback: feedback != null
+                  ? feedback(column.title)
+                  : Material(
+                      elevation: 4,
+                      borderRadius: BorderRadius.circular(12),
+                      child: Container(
+                        padding: const EdgeInsets.all(8),
+                        decoration: BoxDecoration(
+                          color: widget.style?.feedbackBgColor ?? Colors.grey.withOpacity(0.85),
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        child: Text(
+                          column.title,
+                          style: widget.style?.headerTextStyle?.copyWith(
+                            color: widget.style?.feedbackTextColor ?? Colors.white,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ),
                     ),
-                  ),
-                ),
-              ),
               child: DragTarget<int>(
                 onAcceptWithDetails: (draggedIndex) {
                   _swapColumns(draggedIndex.data, index);
@@ -242,7 +246,7 @@ class MegaGridState extends State<MegaGrid> {
                   children: [
                     Row(
                       children: _columns.asMap().entries.map((entry) {
-                        return _buildHeaderCell(entry.value, entry.key);
+                        return _buildHeaderCell(entry.value, entry.key, widget.feedback);
                       }).toList(),
                     ),
                     Column(


### PR DESCRIPTION
This functionality allows you to customize your feedback as you wish.

Add personalized feedback called customFeedback.
Add a feedbackBgColor;
add a feedbackTextColor;

If you want to change the style of your feedback without creating a new widget, you can change the background color using feedbackBgColor and you can use feedbackTextColor to change the color of your text.

If you want to customize other things about your feedback, you can create a customFeedback that returns a widget for your feedback.