### PR TITLE
Add limit to frozen columns width to prevent excessive freezing

### DIFF
--- a/lib/src/widgets/header_cell.dart
+++ b/lib/src/widgets/header_cell.dart
@@ -35,8 +35,9 @@ class HeaderCell extends StatelessWidget {
         onPanUpdate: (details) {
           if (controller.dragStartX != null && controller.resizingColumnIndex != null) {
             final delta = details.globalPosition.dx - controller.dragStartX!;
+            final totalWidth = MediaQuery.of(context).size.width;
             setState(() {
-              controller.updateColumnWidth(controller.resizingColumnIndex!, delta);
+              controller.updateColumnWidth(controller.resizingColumnIndex!, delta, totalWidth);
               controller.dragStartX = details.globalPosition.dx;
             });
           }
@@ -69,6 +70,8 @@ class HeaderCell extends StatelessWidget {
       Offset.zero & overlay.size,
     );
 
+    double totalWidth = MediaQuery.of(context).size.width;
+
     showMenu(
       context: context,
       position: position,
@@ -77,10 +80,10 @@ class HeaderCell extends StatelessWidget {
         if (!controller.isColumnFrozen(index))
           PopupMenuItem(
             value: 'freezeStart',
-            enabled: controller.canFreezeColumn(index),
+            enabled: controller.canFreezeColumn(index, totalWidth),
             onTap: () {
               setState(() {
-                controller.freezeColumnAtStart(index);
+                controller.freezeColumnAtStart(index, totalWidth);
               });
             },
             child: const Text('Freeze at start'),
@@ -88,11 +91,11 @@ class HeaderCell extends StatelessWidget {
         if (!controller.isColumnFrozen(index))
           PopupMenuItem(
             value: 'freezeEnd',
-            enabled: controller.canFreezeColumn(index),
+            enabled: controller.canFreezeColumn(index, totalWidth),
             child: const Text('Freeze at end'),
             onTap: () {
               setState(() {
-                controller.freezeColumnAtEnd(index);
+                controller.freezeColumnAtEnd(index, totalWidth);
               });
             },
           ),


### PR DESCRIPTION
This pull request introduces enhancements to the column freezing functionality in the `ColumnController` and updates the `HeaderCell` widget to support these changes. The main improvements include adding a new constraint for the maximum width of frozen columns and ensuring that the total width is considered during column operations.

### Enhancements to Column Freezing Functionality:

* Added a new parameter `maxFrozenColumnsWidthPercentage` to limit the combined width of frozen columns to a maximum percentage of the total width. (`lib/src/controllers/column_controller.dart`)

* Updated the `updateColumnWidth` method to account for the total width and the widths of frozen columns when adjusting column widths. (`lib/src/controllers/column_controller.dart`)

* Modified the `canFreezeColumn` method to include a check ensuring that the combined width of frozen columns does not exceed the specified maximum percentage of the total width. (`lib/src/controllers/column_controller.dart`)

### Updates to HeaderCell Widget:

* Passed the total width of the context to the `updateColumnWidth`, `canFreezeColumn`, `freezeColumnAtStart`, and `freezeColumnAtEnd` methods to ensure they consider the total width during their operations. (`lib/src/widgets/header_cell.dart`) [[1]](diffhunk://#diff-0f2cd1458d9f7c7bf02352bf86d4eb2bd2cd7b734da36b9736abb19e214dad03R38-R40) [[2]](diffhunk://#diff-0f2cd1458d9f7c7bf02352bf86d4eb2bd2cd7b734da36b9736abb19e214dad03R73-R74) [[3]](diffhunk://#diff-0f2cd1458d9f7c7bf02352bf86d4eb2bd2cd7b734da36b9736abb19e214dad03L80-R98)